### PR TITLE
refactor: Replace react-toggle with react-bootstrap Form.Check

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.27.0",
     "react-scripts": "^5.0.1",
-    "react-toggle": "^4.1.3",
     "timers-browserify": "^2.0.12",
     "util": "^0.12.5",
     "web-vitals": "^2.1.0"

--- a/src/features/graphView/components/ControlPanel.js
+++ b/src/features/graphView/components/ControlPanel.js
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { setMode } from '../graphViewSlice';
 import { setNicknameMapping, resetNicknameMapping, setIsNicknameChangeOpen, setIsShowProtocolsOpen, setShowL4Protocol, setShowL7Protocol } from './controlPanelSlice';
-import Toggle from 'react-toggle';
-import "react-toggle/style.css";
 import { Button, Form} from 'react-bootstrap';
 
 export default function ControlPanel(props) {
@@ -90,14 +88,7 @@ export default function ControlPanel(props) {
         packets && (
             <div style={{ position: 'absolute', top: 70, left: 40, width: "300px", padding: "20px", borderRadius: "15px", border: "1px solid #ccc", backgroundColor: "#fff", boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.1)" }}>
                  {/* Port 분리 토글 버튼 */}
-                 <div style={{ cursor: "pointer", display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}>                        
-                    <Toggle
-                        id='split-toggle'
-                        defaultChecked={mode === 'port'}
-                        onChange={(e) => dispatch(setMode(e.target.checked ? 'port' : 'host'))}
-                    />
-                    <label htmlFor='split-toggle' style={{ marginLeft: '10px',  lineHeight: '0'}}>Split Hosts by Ports</label>
-                </div>
+                <Form.Check type="switch" id="split-toggle" label="Split Hosts by Ports" className="mb-3" defaultChecked={mode === 'port'} onChange={(e) => dispatch(setMode(e.target.checked ? 'port' : 'host'))}></Form.Check>
 
                 {/* 모든 위치 초기화 버튼 */}
                 <div style={{ marginBottom: "20px", width: "100%" }}>
@@ -206,15 +197,7 @@ export default function ControlPanel(props) {
                             </div>
                             {/* L4 Protocol 메뉴 */}
                             {showL4Protocol && (
-                                <div style={{ cursor: "pointer", display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px", borderBottom: "1px dashed #ccc", paddingBottom: "10px" }}>
-                                {/* <div style={{ marginBottom: "20px", width: "100%" }}> */}
-                                    <Toggle
-                                        id='l4-protocol-toggle'
-                                        checked={showL4Protocol}
-                                        onChange={(e) => dispatch(setShowL4Protocol(e.target.checked))}
-                                    />
-                                    <label htmlFor='l4-protocol-toggle' style={{ marginLeft: '10px', lineHeight: '0' }}>Show L4 Protocol</label>
-                                </div>
+                                <Form.Check type="switch" id="l4-protocol-toggle" label="Show L4 Protocol" className="mb-3" defaultChecked={showL4Protocol} onChange={(e) => dispatch(setShowL4Protocol(e.target.checked))}></Form.Check>
                             )}
                             <div 
                                 style={{ cursor: "pointer", display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px" }}
@@ -225,14 +208,7 @@ export default function ControlPanel(props) {
                             </div>
                             {/* L7 Protocol 메뉴 */}
                             {showL7Protocol && (
-                                <div style={{ cursor: "pointer", display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "10px",paddingBottom: "10px" }}>
-                                    <Toggle
-                                        id='l7-protocol-toggle'
-                                        checked={showL7Protocol}
-                                        onChange={(e) => dispatch(setShowL7Protocol(e.target.checked))}
-                                    />
-                                    <label htmlFor='l7-protocol-toggle' style={{ marginLeft: '10px', lineHeight: '0' }}>Show L7 Protocol</label>
-                                </div>
+                                <Form.Check type="switch" id="l7-protocol-toggle" label="Show L7 Protocol" className="mb-3" defaultChecked={showL7Protocol} onChange={(e) => dispatch(setShowL7Protocol(e.target.checked))}></Form.Check>
                             )}
                         </div>
                     )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,7 +3326,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz#707413784dbb3a72aa11c2f2b042a0bef4004170"
   integrity sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==
 
-classnames@^2.2.5, classnames@^2.3.2:
+classnames@^2.3.2:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
@@ -8601,13 +8601,6 @@ react-scripts@^5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
-
-react-toggle@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.1.3.tgz#99193392cca8e495710860c49f55e74c4e6cf452"
-  integrity sha512-WoPrvbwfQSvoagbrDnXPrlsxwzuhQIrs+V0I162j/s+4XPgY/YDAUmHSeWiroznfI73wj+MBydvW95zX8ABbSg==
-  dependencies:
-    classnames "^2.2.5"
 
 react-transition-group@^4.4.5:
   version "4.4.5"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/36667412-729b-47c9-be3b-0b532b16167f)

별건 아니긴 한데...
기존에는 react-toggle 라이브러리를 사용해서 토글을 렌더링했는데
알고보니까 bootstrap 라이브러리에도 토글이 있었어서.. react-toggle 라이브러리를 삭제하고 대신 bootstrap에 있는 토글을 사용하도록 리팩터링함.
사진은 bootstrap의 토글(switch)을 사용한 결과물.