### PR TITLE
[GraphView] 같은 IP가 5개 초과일 경우 라벨에 포트만 표시하고, 아이피는 중앙에 따로 표시

### DIFF
--- a/src/features/graphView/GraphView.js
+++ b/src/features/graphView/GraphView.js
@@ -523,8 +523,8 @@ export default function GraphView() {
                     .text(d => d.ip_addr)
                     .attr("font-size", "12px")
                     .attr("fill", "#555")
-                    .attr("dy", "-1em")
-                    // .attr("text-anchor", "left")
+                    .attr("dx", "5em")
+                    .attr("text-anchor", "middle")
                     .attr("font-weight", "bold")
                     .attr("x", d => d.x)
                     .attr("y", d => d.y);


### PR DESCRIPTION
Closes #7 
애니메이션이랑 약간 따로 노는 느낌 & 위치가 좀 어정쩡하긴 한데 어쨌든 함
![image](https://github.com/user-attachments/assets/dd413964-fbba-4377-9c07-811ef7b0b261)
