### PR TITLE
Fix issue 79

### DIFF
--- a/src/features/graphView/GraphView.js
+++ b/src/features/graphView/GraphView.js
@@ -436,7 +436,7 @@ export default function GraphView() {
                 // .on("dblclick", resetNodePosition)
                 .on("click", (event, d) => {
                     dispatch(addEntry({ metadata: null, formSelections: { hostA: d.ip_addr, portA: d.port, hostB: "", portB: "", radioASelected: true } })); // Add new entry in TimelineView
-                    d3.selectAll(".tooltip").remove();
+                    // d3.selectAll(".tooltip").remove();
                     dispatch(setShouldFocusLastEntry(true));
                 })
             

--- a/src/features/timelineView/components/TimelineEntry.js
+++ b/src/features/timelineView/components/TimelineEntry.js
@@ -581,7 +581,7 @@ export default function TimelineEntry({ entryIndex, hidden }) {
         // Create tooltip div (hidden by default)
         const tooltip = d3.select(svgRef.current.parentNode)
             .append("div")
-            .attr("class", "tooltip")
+            .attr("class", "timeline-tooltip")
             .style("position", "fixed")
             .style("background", "#f9f9f9")
             .style("padding", "5px")


### PR DESCRIPTION
#79 
예전에 timeline view가 나누어져 있던 시절에 작성되었던 
노드나 링크를 클릭했을때, tooltip을 지우는 코드가 남아있어서 생기던 문제였습니다.
추가로 Timeline entry가 켜져있을때, graph view의 툴팁이랑 timeline entry의 tooltip이 색이 같아지는 현상이 존재하여,
그 부분도 수정했습니다.